### PR TITLE
Make desireCapability "plateform" optional

### DIFF
--- a/src/main/java/com/jivesoftware/selenium/pagefactory/framework/browser/mobile/AndroidMobileBrowser.java
+++ b/src/main/java/com/jivesoftware/selenium/pagefactory/framework/browser/mobile/AndroidMobileBrowser.java
@@ -47,7 +47,7 @@ public class AndroidMobileBrowser extends MobileBrowser {
     public DesiredCapabilities getDesiredCapabilities() {
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
         desiredCapabilities.setCapability(CapabilityType.BROWSER_NAME, browserName);
-        desiredCapabilities.setCapability("platform", platform);
+        if (platform!=null) {desiredCapabilities.setCapability("platform", platform);}
         desiredCapabilities.setCapability("platformName", platformName);
         desiredCapabilities.setCapability("platformVersion", platformVersion);
         desiredCapabilities.setCapability("deviceName", deviceName);


### PR DESCRIPTION
Currently, the Selenium capabilty "plateform" must be filled, otherwise the default null value makes connection fail.
The provided tests are failing due to this requirement since not set.
This field should be optional as I propose here.

The same fix should be applied in:
src/main/java/com/jivesoftware/selenium/pagefactory/framework/browser/mobile/IOSMobileBrowser.java
